### PR TITLE
Upgraded GLTFast to Unity's internal package

### DIFF
--- a/Runtime/Scripts/MetaPersonMaterialGenerator.cs
+++ b/Runtime/Scripts/MetaPersonMaterialGenerator.cs
@@ -33,8 +33,13 @@ namespace AvatarSDK.MetaPerson.Loader
 
 		private static bool? isDXT5Encoding = null;
 
-		#region IMaterialGenerator
-		public UnityEngine.Material GenerateMaterial(GLTFast.Schema.Material gltfMaterial, IGltfReadable gltf, bool pointsSupport = false)
+        #region IMaterialGenerator
+        public UnityEngine.Material GenerateMaterial(MaterialBase gltfMaterial, IGltfReadable gltf, bool pointsSupport = false)
+        {
+            return GenerateMaterial((GLTFast.Schema.Material)gltfMaterial, gltf, pointsSupport);
+        }
+
+        public UnityEngine.Material GenerateMaterial(GLTFast.Schema.Material gltfMaterial, IGltfReadable gltf, bool pointsSupport = false)
 		{
 			if (gltfMaterial.name == "AvatarEyelashes")
 				return GenerateMaterial(eyelashesMaterial, gltfMaterial, gltf, false);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "changelogUrl": "https://github.com/avatarsdk/metaperson-loader-unity/blob/main/CHANGELOG.md",
   "licensesUrl": "https://github.com/avatarsdk/metaperson-loader-unity/blob/main/LICENSE.md",
   "dependencies": {
-    "com.atteneder.gltfast": "5.0.4"
+    "com.unity.cloud.gltfast": "6.0.1"
  },
  "keywords": [
     "avatar",


### PR DESCRIPTION
Unity has their own hosted GLTFast package.
This one is easier to integrate into the package manager, since you can check for updates within the editor. Importing the Metaperson Loader with the old code gives an error in 2022.3.13f1, this fixes the error as well.

This also upgrades to GLTFast 6, potentially improving performance with new Burst and Mathematics packages